### PR TITLE
Add the constraints for enum values at the data base level. 

### DIFF
--- a/db/migrate/20220926113643_add_constraints_on_tickets.rb
+++ b/db/migrate/20220926113643_add_constraints_on_tickets.rb
@@ -1,0 +1,8 @@
+class AddConstraintsOnTickets < ActiveRecord::Migration[6.1]
+  def change
+    add_check_constraint :tickets, "status IN (0,1,2,3,4)", name: "status_check"
+    add_check_constraint :tickets, "priority IN (0,1,2,3)", name: "priority_check"
+    add_check_constraint :tickets, "ticket_type IN (0,1)", name: "type_check"
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_16_203859) do
+ActiveRecord::Schema.define(version: 2022_09_26_113643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,9 @@ ActiveRecord::Schema.define(version: 2022_09_16_203859) do
     t.index ["department_id"], name: "index_tickets_on_department_id"
     t.index ["requester_id"], name: "index_tickets_on_requester_id"
     t.index ["resolver_id"], name: "index_tickets_on_resolver_id"
+    t.check_constraint "priority = ANY (ARRAY[0, 1, 2, 3])", name: "priority_check"
+    t.check_constraint "status = ANY (ARRAY[0, 1, 2, 3, 4])", name: "status_check"
+    t.check_constraint "ticket_type = ANY (ARRAY[0, 1])", name: "type_check"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
In case someone accesses our database direct he should not enter the wrong values.