### PR TITLE
Fix: Cron schedule for escalate ticket job 

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,6 +12,6 @@ production:
 
 :schedule:
   EscalateTicketJob: 
-    cron: '* * 12 * * *'
+    cron: '0 12 * * *' # Everyday at 12 pm 
     enabled: true
     active_job: true


### PR DESCRIPTION
Earlier schedule was set to run the job from 12pm to 1pm every second which did not made any sense. Escalation job is a notification mail to resolvers and department heads, which need to be sent only once.