### PR TITLE
increase the expiry time of jwt

### DIFF
--- a/app/services/json_web_token.rb
+++ b/app/services/json_web_token.rb
@@ -2,7 +2,7 @@
 
 class JsonWebToken
   class << self
-    def encode(payload, exp = 24.hours.from_now)
+    def encode(payload, exp = 1.week.from_now)
       payload[:exp] = exp.to_i
       JWT.encode(payload, secret_key_base)
     rescue StandardError


### PR DESCRIPTION
Increased the expiry time of jwt token from 24 hours to one week inorder to increase logout time at front end.